### PR TITLE
#6 Docker in Molecule

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -37,12 +37,12 @@ ansible:
 
 # configuration options for the internal call to vagrant
 vagrant:
-  # molecules --platform option will look for these names
   raw_config_args:
     - "landrush.enabled = true"
     - "landrush.tld = 'vm'"
     - "landrush.guest_redirect_dns = false"
 
+  # molecules --platform option will look for these names
   platforms:
     - name: Debian8
       box: debian/jessie64
@@ -71,3 +71,49 @@ vagrant:
         - network_name: private_network
           type: dhcp
           auto_config: true
+
+docker:
+  containers:
+    - name: mysql
+      ansible_groups:
+        - test01
+
+      # We are using this image because the default Debian image has
+      # Python 2.7.9 and the playbook won't deploy
+      image: python
+      image_version: 2.7.13-jessie
+
+      # All these parameters are needed for Docker testing with systemd
+      privileged: True
+      cap_add:
+        - SYS_ADMIN
+      volume_mounts:
+        - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      command: '/lib/systemd/systemd'
+
+    - name: mysqlUpgrade
+      ansible_groups:
+        - test01
+
+      # We are using this image because the default Debian image has
+      # Python 2.7.9 and the playbook won't deploy
+      image: python
+      image_version: 2.7.13-jessie
+
+      # All these parameters are needed for Docker testing with systemd
+      privileged: True
+      cap_add:
+        - SYS_ADMIN
+      volume_mounts:
+        - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      command: '/lib/systemd/systemd'
+
+verifier:
+  name: testinfra
+  options:
+    # We have to override these options because, when Docker driver selected,
+    # Testinfra uses Docker as backend connection instead of Ansible and the
+    # fixture in tests/test_ansible.yml won't work and neither will testinfra
+    # find the containers
+    connection: ansible
+    ansible-inventory: .molecule/ansible_inventory

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -18,6 +18,12 @@
         state: present
         install_recommends: no
 
+    # This is necessary for Docker driver tests
+    - name: Restart MySQL
+      systemd:
+        service: mysql
+        state: started
+
     - name: Ensure root password is set on first installation
       mysql_user:
         name: root


### PR DESCRIPTION
Added Docker driver configuration in molecule.yml. Added task to ensure MySQL service is started needed if Molecule is using Docker, I do not exactly know why in tests/playbook.yml