### PR TITLE
Fixing #4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,8 @@ mysql_users: []
 #     host: 127.0.0.1
 #     password: secret
 #     priv: [ *.*:USAGE ]
+
+# Remounting settings
+mysql_remount_run: true
+## This variable has to include the magnitude M,G...
+mysql_remount_run_size: 512M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,4 +77,4 @@ mysql_users: []
 # Remounting settings
 mysql_remount_run: true
 ## This variable has to include the magnitude M,G...
-mysql_remount_run_size: 512M
+mysql_remount_run_partition_size: 512M

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,10 +1,11 @@
 ---
 
 - name: MySQL | Remounting /run
-  shell: mount -t tmpfs tmpfs /run -o remount,size=32M
+  shell: mount -t tmpfs tmpfs /run -o remount,size={{ mysql_remount_run_size }}
   changed_when: false
   tags:
     skip_ansible_lint
+  when: mysql_remount_run
 
 - name: MYSQL | Configuring service
   systemd:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: MySQL | Remounting /run
-  shell: mount -t tmpfs tmpfs /run -o remount,size={{ mysql_remount_run_size }}
+  shell: mount -t tmpfs tmpfs /run -o remount,size={{ mysql_remount_run_partition_size }}
   changed_when: false
   tags:
     skip_ansible_lint


### PR DESCRIPTION
> Remounting /run to a 32M size partition makes systemd have very little amount of memory (so daemon-reload can't be done, for instance), probably not enough when there are more services running. I suggest changing the value of the task to a variable, default it to 512M and set another variable that we will use as a condition to this task to be run (default value: true, task will be run).