### PR TITLE
#34 adding default value for mysql_datadir variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista-tech/mysql-role/tree/develop)
+### Fixed
+- [#34](https://github.com/idealista/mysql-role/issues/34) *Adding default value for mysql_datadir variable* @dortegau
 
 ## [2.0.0](https://github.com/idealista-tech/mysql-role/tree/2.0.0) (22/03/2018)
 [Full Changelog](https://github.com/idealista/mysql-role/compare/2.0.0...1.3.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ mysql_service_state: started
 # Files & Paths
 mysql_config_file: /etc/mysql/my.cnf
 mysql_pid_file: /var/run/mysqld/mysqld.pid
+mysql_datadir: /var/lib/mysql
 
 # Databases.
 mysql_databases: []
@@ -57,7 +58,7 @@ mysql_global_variables:
       socket: /var/run/mysqld/mysqld.sock
       basedir: /usr/
       tmpdir: /tmp
-      datadir: /var/lib/mysql
+      datadir: "{{ mysql_datadir }}"
       lc-messages-dir: /usr/share/mysql
       pid_file: "{{ mysql_pid_file }}"
       slow_launch_time: 2
@@ -71,7 +72,7 @@ mysql_global_variables:
       max_connections: 151
       wait_timeout: 28800
       sql_mode: ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
-      innodb_file_per_table: ON
+      innodb_file_per_table: "ON"
       innodb_buffer_pool_size: 256M
       innodb_flush_log_at_trx_commit: 1
       innodb_lock_wait_timeout: 50
@@ -80,7 +81,7 @@ mysql_global_variables:
       general_log_file: /var/log/mysql/mysql.log
       log_syslog_tag: mysql
       slow_query_log_file: /var/log/mysql/mysql-slow.log
-      slow_query_log: ON
+      slow_query_log: "ON"
     mysqldump:
       quick: 1
       max_allowed_packet: 64M


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Created new mysql_datadir variable in _defaults/main.yml_

### Benefits

Is not neccesary to provide a default location for MySQL's datadir

### Possible Drawbacks

AFAIK there aren't possible drawbacks

### Applicable Issues

#34 
