### PR TITLE
#35 Provide additional settings as option files included in playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista-tech/mysql-role/tree/develop)
+### Added
+- [#35](https://github.com/idealista/mysql-role/issues/35) *Provide additional settings as option files included in playbook* @dortegau
+
 ### Fixed
 - [#34](https://github.com/idealista/mysql-role/issues/34) *Adding default value for mysql_datadir variable* @dortegau
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,11 @@ mysql_config_file: /etc/mysql/my.cnf
 mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_datadir: /var/lib/mysql
 
+# Allowing playbooks to provide external option files
+mysql_extra_conf_include_dir: /etc/mysql/conf.d/
+mysql_extra_conf_playbook_path: "{{ playbook_dir }}/files/mysql/conf"
+mysql_extra_conf_template_playbook_path: "{{ playbook_dir }}/templates/mysql/conf"
+
 # Databases.
 mysql_databases: []
 #   - name: example
@@ -45,11 +50,11 @@ mysql_remount_run_partition_size: 512M
 ## https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
 mysql_global_variables:
   include_dirs:
-    - /etc/mysql/conf.d/
+    - "{{ mysql_extra_conf_include_dir }}"
   groups:
     client:
       user: "{{ mysql_user }}"
-      password: mysql_root_password
+      password: "{{ mysql_root_password }}"
       port: 3306
       socket: /var/run/mysqld/mysqld.sock
     mysqld:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ mysql_pid_file: /var/run/mysqld/mysqld.pid
 mysql_datadir: /var/lib/mysql
 
 # Allowing playbooks to provide external option files
-mysql_extra_conf_include_dir: /etc/mysql/conf.d/
+mysql_extra_conf_include_dir: /etc/mysql/conf.d
 mysql_extra_conf_playbook_path: "{{ playbook_dir }}/files/mysql/conf"
 mysql_extra_conf_template_playbook_path: "{{ playbook_dir }}/templates/mysql/conf"
 

--- a/molecule/default/files/mysql/conf/test_file.cnf
+++ b/molecule/default/files/mysql/conf/test_file.cnf
@@ -1,0 +1,2 @@
+# Empty file to test !includedir directive with additional option files
+# provided as file

--- a/molecule/default/templates/mysql/conf/test_template.cnf.j2
+++ b/molecule/default/templates/mysql/conf/test_template.cnf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+# Empty template to test !includedir directive with additional option files
+# provided as template

--- a/molecule/default/tests/test_default.yml
+++ b/molecule/default/tests/test_default.yml
@@ -27,6 +27,23 @@ file:
     group: {{ mysql_group }}
     exists: true
     filetype: directory
+  {{ mysql_extra_conf_include_dir }}:
+    owner: {{ mysql_user }}
+    group: {{ mysql_group }}
+    exists: true
+    filetype: directory
+  "{{ mysql_extra_conf_include_dir }}/test_file.cnf":
+    owner: {{ mysql_user }}
+    group: {{ mysql_group }}
+    exists: true
+    filetype: file
+    mode: "0600"
+  "{{ mysql_extra_conf_include_dir }}/test_template.cnf":
+    owner: {{ mysql_user }}
+    group: {{ mysql_group }}
+    exists: true
+    filetype: file
+    mode: "0600"
 
 mount:
   /run:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -18,6 +18,50 @@
     mode: 0600
   notify: restart mysql
 
+- name: MySQL | Ensure additional options file include dir exists
+  file:
+    path: "{{ mysql_extra_conf_include_dir }}"
+    state: directory
+    owner: "{{ mysql_user }}"
+    group: "{{ mysql_group }}"
+    mode: 0600
+
+- name: MySQL | Ensure additional options file and template paths exists
+  file:
+    path: "{{ mysql_extra_conf_include_dir }}/{{ item.path }}"
+    state: directory
+    owner: "{{ mysql_user }}"
+    group: "{{ mysql_group }}"
+    mode: 0600
+  with_filetree:
+    - "{{ mysql_extra_conf_playbook_path }}/"
+    - "{{ mysql_extra_conf_template_playbook_path }}/"
+  when: item.state == "directory"
+
+- name: MySQL | Copy extra option files (provided by playbooks)
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ mysql_extra_conf_include_dir }}/{{ item.path }}"
+    owner: "{{ mysql_user }}"
+    group: "{{ mysql_group }}"
+    mode: 0600
+  with_filetree:
+    - "{{ mysql_extra_conf_playbook_path }}/"
+  when: item.state == "file"
+  notify: restart mysql
+
+- name: MySQL | Copy extra option files templates (provided by playbooks)
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ mysql_extra_conf_include_dir }}/{{ item.path | splitext | first }}"  # This is to remove .j2 extension
+    owner: "{{ mysql_user }}"
+    group: "{{ mysql_group }}"
+    mode: 0600
+  with_filetree:
+    - "{{ mysql_extra_conf_template_playbook_path }}/"
+  when: item.state == "file"
+  notify: restart mysql
+
 - name: MySQL | Ensure datadir exists
   file:
     path: "{{ mysql_datadir }}"
@@ -30,13 +74,11 @@
   ignore_errors: "yes"
   changed_when: false
 
-- name: MySQL | Flush handlers to restart MySQL after previous initialization
-  meta: flush_handlers
-
 - name: MySQL | Ensure MySQL is started and enabled on boot
   service:
     name: mysql
     state: started
     enabled: "yes"
+
 - name: MySQL | Flush handlers to restart MySQL after previous initialization
   meta: flush_handlers


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Adding the ability to use additional option files in a preconfigured path (defined in default vars)

### Benefits

Additional settings could be provided as option files (including templates and files with the playbook)

### Applicable Issues

#35 